### PR TITLE
Pin containers used to specific image tags

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,7 @@
 services:
   spark-iceberg:
-    image: tabulario/spark-iceberg
+    image: tabulario/spark-iceberg:3.5.5_1.8.1
     container_name: spark-iceberg
-    build: spark/
     volumes:
       - ./docker_demo/spark/warehouse:/home/iceberg/warehouse
       - ./docker_demo/spark/notebooks:/home/iceberg/notebooks/notebooks
@@ -18,7 +17,7 @@ services:
       - streambased.env
 
   trino:
-    image: trinodb/trino
+    image: trinodb/trino:474
     container_name: trino
     ports:
       - 9080:9080


### PR DESCRIPTION
Ensures that reasonably recent builds (and associated iceberg dependencies) for both spark and trino are used.
In Spark Iceberg 1.5.0 there are bugs that cause issues with skip reading Avro files (skipping to next sync block fails due to truncated exception on HttpChunkedInputStream close handling).